### PR TITLE
Fix two typescript errors

### DIFF
--- a/pulltorefresh.d.ts
+++ b/pulltorefresh.d.ts
@@ -41,6 +41,7 @@ declare module "nativescript-pulltorefresh" {
         /**
          * Raised when a refresh event occurs.
          */
+        on(event: string, callback: (args: observable.EventData) => void, thisArg?: any);
         on(event: "refresh", callback: (args: observable.EventData) => void, thisArg?: any);
     }
 


### PR DESCRIPTION
fix (hide) two typescript errors:

node_modules/nativescript-pulltorefresh/pulltorefresh.d.ts(13,18): error TS2415: Class 'PullToRefresh' incorrectly extends base class 'ContentView'.
  Types of property 'on' are incompatible.
    Type '(event: "refresh", callback: (args: EventData) => void, thisArg?: any) => any' is not assignable to type '{ (eventNames: string | GestureTypes, callback: (data: EventData) => void, thisArg?: any): any; (...'.
node_modules/nativescript-pulltorefresh/pulltorefresh.d.ts(45,9): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
